### PR TITLE
父子模板告警策略覆盖

### DIFF
--- a/g/g.go
+++ b/g/g.go
@@ -8,8 +8,9 @@ import (
 // change log
 // 2.0.1: bugfix HistoryData limit
 // 2.0.2: clean stale data
+// 2.0.3: get last match strategy
 const (
-	VERSION = "2.0.2"
+	VERSION = "2.0.3"
 )
 
 func init() {

--- a/store/judge.go
+++ b/store/judge.go
@@ -20,7 +20,8 @@ func CheckStrategy(L *SafeLinkedList, firstItem *model.JudgeItem, now int64) {
 	if !exists {
 		return
 	}
-
+	
+	var match_strategies []*model.Strategy
 	for _, s := range strategies {
 		// 因为key仅仅是endpoint和metric，所以得到的strategies并不一定是与当前judgeItem相关的
 		// 比如lg-dinp-docker01.bj配置了两个proc.num的策略，一个name=docker，一个name=agent
@@ -36,8 +37,16 @@ func CheckStrategy(L *SafeLinkedList, firstItem *model.JudgeItem, now int64) {
 		if !related {
 			continue
 		}
-
-		judgeItemWithStrategy(L, s, firstItem, now)
+		
+		// if parent template only have metric without tags, this strategy will pass thru; 
+		// and then child template have detail metric and tags, also matched; 
+		// so we have at least two strategies when iterator the strategies, the last one is what we want.
+		match_stragies = append(match_strategies, &s)
+	}
+	
+	if len(match_strategies) > 0 {
+	 	// chose the last one strategy in match_strategies.
+	 	judgeItemWithStrategy(L, *match_strategies[len(match_stragies) - 1], firstItem, now)
 	}
 }
 

--- a/store/judge.go
+++ b/store/judge.go
@@ -41,13 +41,19 @@ func CheckStrategy(L *SafeLinkedList, firstItem *model.JudgeItem, now int64) {
 
 		// if parent template only have metric without tags, this strategy will pass thru;
 		// and then child template have detail metric and tags, also matched;
-		// so we have at least two strategies when iterator the strategies, the last one is what we want.
+		// so we have at least two strategies when iterator the strategies, select what we want.
 		match_strategies = append(match_strategies, s)
 	}
 
 	if len(match_strategies) > 0 {
-		// chose the last one strategy in match_strategies.
-		judgeItemWithStrategy(L, match_strategies[len(match_strategies)-1], firstItem, now)
+		// select the max length tags strategy
+		var max_tag_strategy model.Strategy = match_strategies[0]
+		for _, strategy := range match_strategies {
+			if len(strategy.Tags) > len(max_tag_strategy.Tags) {
+				max_tag_strategy = strategy
+			}
+		}
+		judgeItemWithStrategy(L, max_tag_strategy, firstItem, now)
 	}
 }
 

--- a/store/judge.go
+++ b/store/judge.go
@@ -3,9 +3,10 @@ package store
 import (
 	"encoding/json"
 	"fmt"
+	"log"
+
 	"github.com/open-falcon/common/model"
 	"github.com/open-falcon/judge/g"
-	"log"
 )
 
 func Judge(L *SafeLinkedList, firstItem *model.JudgeItem, now int64) {
@@ -20,7 +21,7 @@ func CheckStrategy(L *SafeLinkedList, firstItem *model.JudgeItem, now int64) {
 	if !exists {
 		return
 	}
-	
+
 	var match_strategies []*model.Strategy
 	for _, s := range strategies {
 		// 因为key仅仅是endpoint和metric，所以得到的strategies并不一定是与当前judgeItem相关的
@@ -37,16 +38,16 @@ func CheckStrategy(L *SafeLinkedList, firstItem *model.JudgeItem, now int64) {
 		if !related {
 			continue
 		}
-		
-		// if parent template only have metric without tags, this strategy will pass thru; 
-		// and then child template have detail metric and tags, also matched; 
+
+		// if parent template only have metric without tags, this strategy will pass thru;
+		// and then child template have detail metric and tags, also matched;
 		// so we have at least two strategies when iterator the strategies, the last one is what we want.
-		match_stragies = append(match_strategies, &s)
+		match_strategies = append(match_strategies, &s)
 	}
-	
+
 	if len(match_strategies) > 0 {
-	 	// chose the last one strategy in match_strategies.
-	 	judgeItemWithStrategy(L, *match_strategies[len(match_stragies) - 1], firstItem, now)
+		// chose the last one strategy in match_strategies.
+		judgeItemWithStrategy(L, *match_strategies[len(match_strategies)-1], firstItem, now)
 	}
 }
 

--- a/store/judge.go
+++ b/store/judge.go
@@ -22,7 +22,7 @@ func CheckStrategy(L *SafeLinkedList, firstItem *model.JudgeItem, now int64) {
 		return
 	}
 
-	var match_strategies []*model.Strategy
+	var match_strategies []model.Strategy
 	for _, s := range strategies {
 		// 因为key仅仅是endpoint和metric，所以得到的strategies并不一定是与当前judgeItem相关的
 		// 比如lg-dinp-docker01.bj配置了两个proc.num的策略，一个name=docker，一个name=agent
@@ -42,12 +42,12 @@ func CheckStrategy(L *SafeLinkedList, firstItem *model.JudgeItem, now int64) {
 		// if parent template only have metric without tags, this strategy will pass thru;
 		// and then child template have detail metric and tags, also matched;
 		// so we have at least two strategies when iterator the strategies, the last one is what we want.
-		match_strategies = append(match_strategies, &s)
+		match_strategies = append(match_strategies, s)
 	}
 
 	if len(match_strategies) > 0 {
 		// chose the last one strategy in match_strategies.
-		judgeItemWithStrategy(L, *match_strategies[len(match_strategies)-1], firstItem, now)
+		judgeItemWithStrategy(L, match_strategies[len(match_strategies)-1], firstItem, now)
 	}
 }
 


### PR DESCRIPTION
修复 #10 ，解决父子模板告警策略包含关系，主要考虑子模板覆盖父模板告警策略的情况。
