### PR TITLE
 增加一个http接口，改变judge内存中的event的状态

### DIFF
--- a/g/var.go
+++ b/g/var.go
@@ -74,3 +74,10 @@ func (this *SafeEventMap) Set(key string, event *model.Event) {
 	defer this.Unlock()
 	this.M[key] = event
 }
+
+//
+func (this *SafeEventMap) Getall() map[string]*model.Event {
+	this.RLock()
+	defer this.RUnlock()
+	return this.M
+}

--- a/http/info.go
+++ b/http/info.go
@@ -24,6 +24,31 @@ func configInfoRoutes() {
 		RenderDataJson(w, m[urlParam])
 	})
 
+	//e.g. /eventall/
+	http.HandleFunc("/eventall/", func(w http.ResponseWriter, r *http.Request) {
+		m := g.LastEvents.Getall()
+		RenderDataJson(w, m)
+	})
+
+	//e.g. /event/eventid
+	http.HandleFunc("/event/", func(w http.ResponseWriter, r *http.Request) {
+		urlParam := r.URL.Path[len("/event/"):]
+		m,_ := g.LastEvents.Get(urlParam)
+		RenderDataJson(w, m)
+	})
+
+	//e.g. /postevent/eventid
+	http.HandleFunc("/postevent/", func(w http.ResponseWriter, r *http.Request) {
+		urlParam := r.URL.Path[len("/postevent/"):]
+		m,exists:= g.LastEvents.Get(urlParam)
+		if exists {
+			m.Status="OK"
+			store.Send(m)
+		}
+		RenderDataJson(w, m)
+	})
+
+
 	http.HandleFunc("/count", func(w http.ResponseWriter, r *http.Request) {
 		sum := 0
 		arr := []string{"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f"}

--- a/store/judge.go
+++ b/store/judge.go
@@ -82,6 +82,12 @@ func sendEvent(event *model.Event) {
 	rc.Do("LPUSH", redisKey, string(bs))
 }
 
+//store.Send()
+func Send(event *model.Event){
+	sendEvent(event)
+}
+
+
 func CheckExpression(L *SafeLinkedList, firstItem *model.JudgeItem, now int64) {
 	keys := buildKeysFromMetricAndTags(firstItem)
 	if len(keys) == 0 {


### PR DESCRIPTION
当在http://alarm:9912中手工solved未恢复的报警，仅仅是删除alarm内存中的记录，Judge内存中相关的状态没有改变，实际情况应为同时修改Judge内存状态。所以增加这个http接口，能够在solved alarm的同时，恢复event的状态为OK。 接口说明: http://judge/eventall 查看所有event；http://judge/event/id 查看某条event ；http://judge/postevent/id ，将event状态置为OK