### PR TITLE
add timeout to rpc call

### DIFF
--- a/cfg.example.json
+++ b/cfg.example.json
@@ -13,7 +13,8 @@
     "hbs": {
         "servers": ["127.0.0.1:6030"],
         "timeout": 300,
-        "interval": 60
+        "interval": 60,
+		"callTimeout": 5
     },
     "alarm": {
         "enabled": true,

--- a/cron/strategy.go
+++ b/cron/strategy.go
@@ -20,7 +20,7 @@ func SyncStrategies() {
 
 func syncStrategies() {
 	var strategiesResponse model.StrategiesResponse
-	err := g.HbsClient.Call("Hbs.GetStrategies", model.NullRpcRequest{}, &strategiesResponse)
+	err := g.HbsClient.CallTimeout("Hbs.GetStrategies", model.NullRpcRequest{}, &strategiesResponse, time.Duration(g.Config().Hbs.CallTimeout)*time.Second)
 	if err != nil {
 		log.Println("[ERROR] Hbs.GetStrategies:", err)
 		return
@@ -54,7 +54,7 @@ func rebuildStrategyMap(strategiesResponse *model.StrategiesResponse) {
 
 func syncExpression() {
 	var expressionResponse model.ExpressionResponse
-	err := g.HbsClient.Call("Hbs.GetExpressions", model.NullRpcRequest{}, &expressionResponse)
+	err := g.HbsClient.CallTimeout("Hbs.GetExpressions", model.NullRpcRequest{}, &expressionResponse, time.Duration(g.Config().Hbs.CallTimeout)*time.Second)
 	if err != nil {
 		log.Println("[ERROR] Hbs.GetExpressions:", err)
 		return

--- a/g/cfg.go
+++ b/g/cfg.go
@@ -18,9 +18,10 @@ type RpcConfig struct {
 }
 
 type HbsConfig struct {
-	Servers  []string `json:"servers"`
-	Timeout  int64    `json:"timeout"`
-	Interval int64    `json:"interval"`
+	Servers     []string `json:"servers"`
+	Timeout     int64    `json:"timeout"`
+	Interval    int64    `json:"interval"`
+	CallTimeout int64    `json:"callTimeout"`
 }
 
 type RedisConfig struct {

--- a/g/g.go
+++ b/g/g.go
@@ -8,8 +8,9 @@ import (
 // change log
 // 2.0.1: bugfix HistoryData limit
 // 2.0.2: clean stale data
+// 2.0.3: add timeout to sync strategies and expressions
 const (
-	VERSION = "2.0.2"
+	VERSION = "2.0.3"
 )
 
 func init() {

--- a/g/timeout_rpc_client.go
+++ b/g/timeout_rpc_client.go
@@ -1,0 +1,35 @@
+package g
+
+import (
+	"time"
+	"errors"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+)
+
+type TimeoutRpcClient struct {
+	*rpc.Client
+}
+
+func NewTimeoutRpcClient(network, address string, timeout time.Duration) (*TimeoutRpcClient, error) {
+	conn, err := net.DialTimeout(network, address, timeout)
+	if err != nil {
+		return nil, err
+	}
+
+	return &TimeoutRpcClient {
+		Client: jsonrpc.NewClient(conn),
+	}, nil
+}
+
+func (this *TimeoutRpcClient) CallTimeout(serviceMethod string, args interface{}, reply interface{}, timeout time.Duration) error {
+	call := this.Go(serviceMethod, args, reply, make(chan *rpc.Call, 1))
+
+	select {
+	case callPtr := <-call.Done:
+		return callPtr.Error
+	case <-time.After(timeout):
+		return errors.New("rpc call timeout")
+	}
+}


### PR DESCRIPTION
https://github.com/open-falcon-archive/judge/issues/6

为了解决这个issure的问题，给RPC调用增加了一个超时方法，可以将hbs改用一个fake_server来进行测试

package main

import (
	"net"
	"log"
	"time"
)

func serve(conn *net.Conn) {
	time.Sleep(time.Duration(1000) * time.Second)
}

func main() {
	listener, err := net.Listen("tcp", "0.0.0.0:6030")
	if err != nil {
		log.Println("[ERROR] listen on :6030 failed,", err)
		return
	}

	for {
		conn, err := listener.Accept()
		if err != nil {
			log.Println("[ERROR] accept an new connection failed,", err)
			break
		}
		go serve(&conn)
	}
}